### PR TITLE
Add `Order` to feed definition

### DIFF
--- a/cmd/feed.go
+++ b/cmd/feed.go
@@ -89,6 +89,7 @@ func (rf *RssFilter) HasCategory(category string) bool {
 type RssFeed interface {
 	Reset()
 	GetFeedType() string
+	GetOrder() int
 	GetParam(string) (string, error)
 	GenerateUrl() string
 	GetPublishFormat() string

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -47,7 +47,30 @@ func (cmd *PushCmd) Run(ctx *RunContext) error {
 			return fmt.Errorf("Invalid feed name: %s", ctx.Cli.Push.Feed)
 		}
 	} else {
-		feeds = allFeeds
+		// add our feeds in the specified order
+		feedCnt := len(allFeeds)
+		for i := 1; i <= feedCnt; i++ {
+			for _, feed := range allFeeds {
+				order := ctx.Konf.Int(fmt.Sprintf("feeds.%s.Order", feed))
+				if order == i {
+					feeds = append(feeds, feed)
+				}
+			}
+		}
+
+		// look for any feeds which don't have an order
+		for _, feed := range allFeeds {
+			hasOrder := false
+			for _, x := range feeds {
+				if feed == x {
+					hasOrder = true
+					break
+				}
+			}
+			if !hasOrder {
+				feeds = append(feeds, feed)
+			}
+		}
 	}
 	log.Debugf("feeds = %v", feeds)
 

--- a/cmd/rfm_feed.go
+++ b/cmd/rfm_feed.go
@@ -34,6 +34,7 @@ const (
 // Impliment the RFM feed filter
 type RfmFeed struct {
 	FeedType         string
+	Order            int                   `koanf:"Order"`
 	BaseUrl          string                `koanf:"BaseUrl"`
 	Filters          *map[string]RssFilter `koanf:"Filters"`
 	Results          int64                 `koanf:"Results" param:"l"`
@@ -102,6 +103,10 @@ func (rfm *RfmFeed) GetPublishFormat() string {
 
 func (rfm *RfmFeed) GetFeedType() string {
 	return rfm.FeedType
+}
+
+func (rfm RfmFeed) GetOrder() int {
+	return rfm.Order
 }
 
 func (rfm RfmFeed) GetParam(fieldName string) (string, error) {


### PR DESCRIPTION
Feeds may overlap, so we should specify the feed order so that our push
messages can move from more specific to generic