### PR TITLE
add `skip` command to update cache but do nothing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,6 +60,7 @@ type CLI struct {
 	Download DownloadCmd `kong:"cmd,help='Download the feeds'"`
 	List     ListCmd     `kong:"cmd,help='List the configured feeds'"`
 	Push     PushCmd     `kong:"cmd,help='Send push notifications for new entries'"`
+	Skip     SkipCmd     `kong:"cmd,help='Check feed data and skip entries'"`
 }
 
 func main() {


### PR DESCRIPTION
sometimes you don't want to download entries and need to
update the cache so they are skipped.

Also support --dry-run for push as a no-op